### PR TITLE
fixed contact us form

### DIFF
--- a/src/app/components/footer.jsx
+++ b/src/app/components/footer.jsx
@@ -47,6 +47,8 @@ const FooterSection = () => {
       }, error => {
         console.log(error);  
       });
+    form.current.reset();
+    alert("Form submitted!");
   };
 
   return (


### PR DESCRIPTION
the contact us form was retaining the values after the submission of form, this confuses the user to think his form is not submitted and click on submit button multiple times leading to spamming of hackslash mail. 
fixed the issue by clearing the form on submission and showing a confirmation message that your form is submitted.
